### PR TITLE
Remove extra / from post URLs

### DIFF
--- a/babysteps/all_posts.html
+++ b/babysteps/all_posts.html
@@ -16,7 +16,7 @@ title: All posts
 {% for post in site.posts %}
 <div class="post_section">
     <p class="listing_date">{{ post.date | date_to_long_string }}</p>
-    <a href="{{ site.baseurl }}/{{ post.url }}">
+    <a href="{{ site.baseurl }}{{ post.url }}">
         <h3 class="listing_title">{{ post.title }}</h3>
     </a>
     <!--
@@ -26,7 +26,7 @@ title: All posts
     {% endfor %}
   </div>
 -->
-    <p>{{post.excerpt}} (<a href="{{ site.baseurl }}/{{ post.url }}">read more...)</a></p>
+    <p>{{post.excerpt}} (<a href="{{ site.baseurl }}{{ post.url }}">read more...)</a></p>
     <br>
     <hr>
 </div>

--- a/babysteps/index.html
+++ b/babysteps/index.html
@@ -18,7 +18,7 @@ title: Baby Steps
 {% for post in paginator.posts %}
 <div class="post_section">
   <p class="listing_date">{{ post.date | date_to_long_string }}</p>
-  <a href="{{ site.baseurl }}/{{ post.url }}">
+  <a href="{{ site.baseurl }}{{ post.url }}">
     <h3 class="listing_title">{{ post.title }}</h3>
   </a>
   <!--
@@ -28,7 +28,7 @@ title: Baby Steps
     {% endfor %}
   </div>
 -->
-  <p>{{post.excerpt}} (<a href="{{ site.baseurl }}/{{ post.url }}">read more...)</a></p>
+  <p>{{post.excerpt}} (<a href="{{ site.baseurl }}{{ post.url }}">read more...)</a></p>
   <br>
   <hr>
 </div>


### PR DESCRIPTION
Links to posts from `index.html` and `all_posts.html` always contained an extra `/` in the URL.

Remove the extra `/` when concatenating `site.baseurl` and `post.url`.

Tested locally with jekyll; seems to work.