### PR TITLE
fix horizontal scroll in mobile

### DIFF
--- a/babysteps/Gemfile
+++ b/babysteps/Gemfile
@@ -27,3 +27,8 @@ group :jekyll_plugins do
    gem 'jekyll-spaceship'
 end
 
+# Fix `bundle exec jekyll serve` fails 
+gem "webrick"
+
+# Fix: minima theme not used after overriding `main.scss`
+gem "minima", "~> 2.5"

--- a/babysteps/_includes/head.html
+++ b/babysteps/_includes/head.html
@@ -6,7 +6,6 @@
   <title>{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}</title>
   <meta name="description" content="{{ page.excerpt | default: site.description | strip_html | normalize_whitespace | truncate: 160 | escape }}">
 
-  <link rel="stylesheet" href="{{ "/assets/main.css" | relative_url }}">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title | escape }}" href="{{ "/atom.xml" | relative_url }}">
 

--- a/babysteps/assets/css/app.scss
+++ b/babysteps/assets/css/app.scss
@@ -37,3 +37,9 @@ $on-laptop:        800px;
 
 // Import partials from the `minima` theme.
 @import "minima";
+
+// fix <code> nodes cause horizontal scroll on mobile
+.highlight {
+    overflow-y: auto;
+    width: 100%;
+}


### PR DESCRIPTION
- add overflow-y to pre, code containers

- replace `main.scss` with `assets/css/app.scss` so we properly override `minima` theme.

> This allows code blocks to have a `background-color` to them as the theme devs intended.