### PR TITLE
temporary-lifetimes: Fix small typo on playground link

### DIFF
--- a/babysteps/_posts/2023-03-15-temporary-lifetimes.md
+++ b/babysteps/_posts/2023-03-15-temporary-lifetimes.md
@@ -375,7 +375,7 @@ let x = Foo {
 };)
 ```
 
-* Con: the following example would build again, which leads to a (perhaps surprising) [panic]https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=2e9e4077c3558c3da5d9df9ba717c8af) -- that said, I've never seen a case like this in the wild, the confusion *always* occurs with match
+* Con: the following example would build again, which leads to a (perhaps surprising) [panic](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=2e9e4077c3558c3da5d9df9ba717c8af) -- that said, I've never seen a case like this in the wild, the confusion *always* occurs with match
 
 ```rust!
 use std::cell::RefCell;


### PR DESCRIPTION
The markdown link was simply missing a parenthesis. Great article! I really enjoyed reading through it :)