### PR TITLE
Add machine-readable link to atom feed

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -13,6 +13,11 @@
 
   {{ $mainStyles := resources.Get "scss/main.scss" | toCSS | fingerprint }}
   <link rel="stylesheet" href="{{ $mainStyles.Permalink }}" integrity="{{ $mainStyles.Data.Integrity }}" />
+
+  {{ range .AlternativeOutputFormats -}}
+    {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
+  {{ end -}}
+
 </head>
 
 <body>


### PR DESCRIPTION
This way, I can add your site to my feed reader by just copying its web URL to it, without having to find the RSS button.