### PR TITLE
Polonius, part 2: fix some typos (or maybe I'm just misunderstanding)

### DIFF
--- a/content/blog/2023-09-29-polonius-part-2.markdown
+++ b/content/blog/2023-09-29-polonius-part-2.markdown
@@ -192,7 +192,7 @@ Env_BB3_0 = {
 }
 ```
 
-Following a similar process to before, we conclude that `'0_BB1_3 : '1_BB3_0`.
+Following a similar process to before, we conclude that `'0_BB1_3 : '0_BB3_0`.
 
 
 ## Building the flow-sensitive subset graph
@@ -356,7 +356,7 @@ let x: u32;
 /* P5 */ drop(v);
 ```
 
-What makes this interesting? We create a reference `p` at point `P1` that points at `v`. We then insert a borrow of `x` into the reference `p`. **After that point, the reference `p` is dead, but the loan `L1` is still active** -- this is because it is also stored in `x`. This connection between `p` and `v` is what is key about this example.
+What makes this interesting? We create a reference `p` at point `P1` that points at `v`. We then insert a borrow of `x` into the reference `p`. **After that point, the reference `p` is dead, but the loan `L1` is still active** -- this is because it is also stored in `v`. This connection between `p` and `v` is what is key about this example.
 
 The way that this connection is reflected in the type system is through *[variance]*. In particular, a type `&mut T` is **invariant** with respect to `T`. This means that when you assign one reference to another, the type that they reference must be exactly the same.
 


### PR DESCRIPTION
Another thing I was unsure about - in the beginning, you say:

> The subenvironment relationship Env1 <: Env2 holds if
> - for each variable X in Env2:
>   - X appears in Env1
>   - Env1[X] <: Env2[X]

But later, in "Type-checking the p = q assignment", you say:

> we also have to make the environment `Env_BB2_0` be a subenvironment of the env after `Env_BB2_1`. But since the set of live variables are disjoint, in this case, that doesn’t add anything to the picture.

According to the rules for subenvironments, each variable in `Env_BB2_1` (which is `p`) must also appear in `Env_BB2_0`, however `Env_BB2_0` only contains `q` - how is that resolved?