### PR TITLE
Fix type signature in 2025-02-25-view-types-redux.markdown

### DIFF
--- a/content/blog/2025-02-25-view-types-redux.markdown
+++ b/content/blog/2025-02-25-view-types-redux.markdown
@@ -101,7 +101,7 @@ We would also modify the `add_successful` method to flag what field it needs:
 impl Data {
     pub fn add_successful(
         self: &mut {successful} Self,
-    ) -> impl Iterator<Item = &String> {
+    ) {
        self.successful += 1;
     }
 }
@@ -137,7 +137,7 @@ Consider this function from our example:
 impl Data {
     pub fn add_successful(
         self: &mut {successful} Self,
-    ) -> impl Iterator<Item = &String> {
+    ) {
        self.successful += 1;
     }
 }
@@ -154,7 +154,7 @@ If however you tried to modify a function to access a field not declared as part
 impl Data {
     pub fn add_successful(
         self: &mut {successful} Self,
-    ) -> impl Iterator<Item = &String> {
+    ) {
        assert!(!self.experiments.is_empty()); // <— modified to include this
        self.successful += 1;
     }


### PR DESCRIPTION
Great blog post, thanks for the insights and ideas of what Rust could be like!

Would these view types maybe pave the way to some kind of structural typing?

Probably far out, but maybe something like this could be useful? 🤔

```rust
fn add_successful<T>(x: &mut { successful: u32} T) {
  x.successful += 1;
}
```

Although view types in traits already provide similar functionality.