### PR TITLE
Fix typo: it's -> its

### DIFF
--- a/content/blog/2024-06-21-claim-auto-and-otherwise.markdown
+++ b/content/blog/2024-06-21-claim-auto-and-otherwise.markdown
@@ -26,7 +26,7 @@ For some code, automatically calling `Claim` may be undesirable. For example, so
 
 ## Step 1: Introducing an explicit `Claim` trait
 
-Quick, reading this code, can you tell me anything about it's performance characteristics?
+Quick, reading this code, can you tell me anything about its performance characteristics?
 
 ```rust
 tokio::spawn({


### PR DESCRIPTION
(Since this use of "its" is possessive.)