### PR TITLE
Unify trait hierarchy in move-destruct-forget proposal

### DIFF
--- a/content/blog/2025-10-21-move-destruct-leak.markdown
+++ b/content/blog/2025-10-21-move-destruct-leak.markdown
@@ -16,7 +16,7 @@ Nothing this good comes for free. The big catch of the proposal is that it intro
 The TL;DR of the proposal is that we should:
 
 * Introduce a new "default trait bound" `Forget` and an associated trait hierarchy:
-    * `trait Forget: Drop`, representing values that can be forgotten
+    * `trait Forget: Destruct`, representing values that can be forgotten
     * `trait Destruct: Move`, representing values with a destructor
     * `trait Move: Pointee`, representing values that can be moved
     * `trait Pointee`, the base trait that represents *any value*


### PR DESCRIPTION
This hierarchy is later repeated in code, with Destruct instead of Drop. I am not sure which version you want, but Destruct makes more sense from the heirarchical perspective.