### PR TITLE
Remove stray 'either' in 'must move' blog

### DIFF
--- a/content/blog/2023-03-16-must-move-types.markdown
+++ b/content/blog/2023-03-16-must-move-types.markdown
@@ -130,7 +130,7 @@ pub struct Guard {
 impl !Drop for Guard { }
 ```
 
-When you do this, the type becomes “must move” and any function which has a value of type `Guard` must either move it somewhere else. You might wonder then how you ever terminate — the answer is that one way to “move” the value is to unpack it with a pattern. For example, `Guard` might declare a `log` method:
+When you do this, the type becomes “must move” and any function which has a value of type `Guard` must move it somewhere else. You might wonder then how you ever terminate — the answer is that one way to “move” the value is to unpack it with a pattern. For example, `Guard` might declare a `log` method:
 
 ```rust
 impl Guard {


### PR DESCRIPTION
There is an 'either' without the accompanying 'or'. I could also imagine that it meant to say 'or destructuring/pattern matching it', but the blog already goes on to say that in the next sentence.