### PR TITLE
2026-08-10-cyclic-trait-solving.markdown: fix typo in title ("cylic")

### DIFF
--- a/content/blog/2026-08-10-cyclic-trait-solving.markdown
+++ b/content/blog/2026-08-10-cyclic-trait-solving.markdown
@@ -1,5 +1,5 @@
 ---
-title: "Cylic trait implementations: motivation"
+title: "Cyclic trait implementations: motivation"
 date: 2026-08-10T09:35:40-04:00
 series:
 - "Cyclic trait impls"


### PR DESCRIPTION
Assuming this is meant to say "cyclic" given the file name, series title, and content.