### PR TITLE
2025-01-29-preview-crates.markdown: `~const` is different from `const`

### DIFF
--- a/content/blog/2025-01-29-preview-crates.markdown
+++ b/content/blog/2025-01-29-preview-crates.markdown
@@ -56,7 +56,7 @@ Now, maybe we use this for a while, and we find that people really don't like th
 ```rust
 const_preview::const_item! {
     const fn compute_value<T: const Default>() {
-        // as `~const` is what is implemented today, I'll use it in this example
+        // ...
     }
 }
 ```


### PR DESCRIPTION
Remove the "as `~const` is what is implemented today, I'll use it in this example" comment in the example that doesn't use `~const` in the section about releasing a version 2 of a preview crate.